### PR TITLE
Fix failure to compile by default

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -12,10 +12,10 @@ CD /D %CD%
 DOT.EXE -V
 
 ECHO .svg generating..
-DOT.EXE -Tsvg ".\tree.dot" > ".\out\tree.svg"
+DOT.EXE -Tsvg ".\tree.dot" > ".\tree.svg"
 
 ECHO .png generating..
-DOT.EXE -Tpng ".\tree.dot" > ".\out\tree.png"
+DOT.EXE -Tpng ".\tree.dot" > ".\tree.png"
 
 TIMEOUT /t 10
 @REM PAUSE

--- a/compile.sh
+++ b/compile.sh
@@ -8,9 +8,9 @@ then
 fi
 
 echo ".svg generating.."
-dot -Tsvg "./tree.dot" > "./out/tree.svg"
+dot -Tsvg "./tree.dot" > "./tree.svg"
 
 echo ".png generating.."
-dot -Tpng "./tree.dot" > "./out/tree.png"
+dot -Tpng "./tree.dot" > "./tree.png"
 
 exit 0


### PR DESCRIPTION
The compilation scripts attempt to output to a non-existent `/out` folder due to the refactor
Fixed this by simply having it output to the root folder and overwrite the existing files, like it originally did.