### PR TITLE
Add two anglophone codebases

### DIFF
--- a/tree.dot
+++ b/tree.dot
@@ -146,6 +146,7 @@ digraph G {
 		"BayStation (GPL)"              -> "Black Tyranny"
 		"BayStation (GPL)"              -> "BestRP"
 		"BayStation (GPL)"              -> "Colonial Marines"
+		"BayStation (GPL)"              -> "Hypatia"
 		"BayStation (GPL)"              -> "Paradise"
 		"BayStation (GPL)"              -> "Prishtina"
 		"BayStation (GPL)"              -> "Project Misery"
@@ -191,6 +192,7 @@ digraph G {
 		"InterStation-Two"              -> "Ava's Battlegrounds (IS2)"
 		"Lawful Green"                  -> "Green (/vg/)"
 		"Lebensraum"                    -> "Civilization 13"
+		"Nebula"                        -> "Argos"
 		"Nebula"                        -> "Hestia"
 		"No Mans's Land"                -> "Lebensraum"
 		"November"                      -> "Lifeweb" [color = red]


### PR DESCRIPTION
Adds those two anglophone codebases:
* Hypatia (2013 version of GPL Bay so far)
* Argos (Nebula fork)

These are on behalf of an acquaintance of mine. There are currently more suggestions to add few more, including a currently active and updated version of Hypatia worked on by an one-man army. Although I need to get these suggestions discussed and sorted out first.